### PR TITLE
Migrate to Alpine, Update GoBGP

### DIFF
--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -1,27 +1,26 @@
-FROM ubuntu:17.10
+FROM alpine:3.10
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update
-RUN apt-get remove -y binutils
-RUN apt-get install -y python3.6
-RUN apt-get install -y python3-pip
-RUN apt-get install -y python-dev
-RUN apt-get install -y uwsgi-plugin-python
-RUN apt-get install -y nginx
-RUN apt-get install -y supervisor
-RUN echo 'Etc/UTC' >/etc/timezone
-RUN apt-get install -y --reinstall tzdata
-COPY nginx/flask.conf /etc/nginx/sites-available/
-COPY supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+RUN apk add --no-cache python3 && \
+    if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --no-cache --upgrade pip setuptools wheel && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    apk add --no-cache supervisor nginx uwsgi-python3 python3-dev build-base linux-headers pcre-dev && \
+    mkdir -p /supervisor/
+COPY nginx/flask.conf /etc/nginx/conf.d/flask.conf
+COPY supervisor/supervisord.conf /supervisor/supervisord.conf
 COPY app/requirements.txt /tmp/requirements.txt
 
 RUN mkdir -p /var/log/nginx/app /var/log/uwsgi/app /var/log/supervisor /var/www/app \
-    && rm /etc/nginx/sites-enabled/default \
-    && ln -s /etc/nginx/sites-available/flask.conf /etc/nginx/sites-enabled/flask.conf \
+    && mkdir /www \
+    && mkdir /run/nginx \
+    && rm /etc/nginx/conf.d/default.conf \
+    && chown -R nginx:nginx /var/lib/nginx \
+    && chown -R nginx:nginx /www \
     && echo "daemon off;" >> /etc/nginx/nginx.conf \
     && pip3 install -r /tmp/requirements.txt \
-    && chown -R www-data:www-data /var/www/app \
-    && chown -R www-data:www-data /var/log
+    && chown -R nginx:nginx /var/www/app \
+    && chown -R nginx:nginx /var/log
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c/supervisor/supervisord.conf"]

--- a/flask/nginx/flask.conf
+++ b/flask/nginx/flask.conf
@@ -1,7 +1,7 @@
 
 server {
-    listen      80;
-    server_name localhost;
+    listen      80 default_server;
+    server_name _;
     charset     utf-8;
     client_max_body_size 75M;
 

--- a/flask/supervisor/supervisord.conf
+++ b/flask/supervisor/supervisord.conf
@@ -5,4 +5,4 @@ nodaemon=true
 command=/usr/sbin/nginx
 
 [program:uwsgi]
-command =/usr/local/bin/uwsgi --ini  /var/www/app/uwsgi.ini
+command =/usr/bin/uwsgi --ini  /var/www/app/uwsgi.ini

--- a/gobgp/Dockerfile
+++ b/gobgp/Dockerfile
@@ -1,23 +1,25 @@
-# FROM osrg/gobgp:latest
-FROM ubuntu:17.10
+FROM alpine:3.10
 
-RUN apt-get update
-RUN apt-get remove -y binutils
-RUN apt-get install -y python3.6
-RUN apt-get install -y python3-pip
-RUN apt-get install -y wget
+RUN apk add --no-cache python3 && \
+    if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --no-cache --upgrade pip setuptools wheel && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    apk add --no-cache wget
+
 COPY ./requirements.txt /tmp/requirements.txt
-RUN pip3 install -r /tmp/requirements.txt
-RUN wget https://github.com/osrg/gobgp/releases/download/v1.32/gobgp_1.32_linux_amd64.tar.gz
-RUN tar -xzvf gobgp_1.32_linux_amd64.tar.gz
-RUN mkdir /root/gobgp
-RUN mv gobgp /root/gobgp/gobgp
-RUN mv gobgpd /root/gobgp/gobgpd
-RUN chmod +x /root/gobgp/gobgp
-RUN chmod +x /root/gobgp/gobgpd
+RUN pip3 install -r /tmp/requirements.txt \
+  && wget https://github.com/osrg/gobgp/releases/download/v2.8.0/gobgp_2.8.0_linux_amd64.tar.gz \
+  && tar -xzvf gobgp_2.8.0_linux_amd64.tar.gz \
+  && mkdir /root/gobgp \
+  && mv gobgp /root/gobgp/gobgp \
+  && mv gobgpd /root/gobgp/gobgpd \
+  && chmod +x /root/gobgp/gobgp \
+  && chmod +x /root/gobgp/gobgpd
 COPY ./gobgpd.conf /root/gobgp/gobgpd.conf
 COPY ./entrypoint.sh /root/gobgp/entrypoint.sh
-RUN chmod +x /root/gobgp/entrypoint.sh
 COPY ./startup.sh /root/gobgp/startup.sh
-RUN chmod +x /root/gobgp/startup.sh
-ENTRYPOINT /root/gobgp/entrypoint.sh
+RUN chmod +x /root/gobgp/entrypoint.sh \
+  && chmod +x /root/gobgp/startup.sh
+ENTRYPOINT [ "/root/gobgp/entrypoint.sh" ]

--- a/gobgp/entrypoint.sh
+++ b/gobgp/entrypoint.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 exec /root/gobgp/gobgpd -f /root/gobgp/gobgpd.conf &
-exec /root/gobgp/startup.sh 
+exec /root/gobgp/startup.sh


### PR DESCRIPTION
As the required FROM was no longer supported (it was Ubuntu 17.10) as pointed out in issue #3 this was breaking the build process.

I've taken the option to move the base across to Alpine, which results in a somewhat quicker build and one that works at the moment.

The version of GoBGP has also been updated to the most recent that has been released at the moment - 2.8.0 up from 1.32.

In terms of testing, I've had it running for the last three hours with full BGP tables heading into it with a decent amount of updates and it's been fine for me but YMMV.